### PR TITLE
Check for existence of snipe-it folder

### DIFF
--- a/tasks/snipeit.yml
+++ b/tasks/snipeit.yml
@@ -6,8 +6,8 @@
 
 - name: Create folder if it doesnt exist
   ansible.builtin.file:
-     path: "{{ snipe_install_dir }}"
-     state: directory
+    path: "{{ snipe_install_dir }}"
+    state: directory
     mode: '0755'
   when: not snipeit_folder_check.stat.exists
   become: yes

--- a/tasks/snipeit.yml
+++ b/tasks/snipeit.yml
@@ -8,7 +8,7 @@
   ansible.builtin.file:
      path: "{{ snipe_install_dir }}"
      state: directory
-    mode: '0753'
+    mode: '0755'
   when: not snipeit_folder_check.stat.exists
   become: yes
 

--- a/tasks/snipeit.yml
+++ b/tasks/snipeit.yml
@@ -1,3 +1,17 @@
+- name: Check if install-folder already exists
+  ansible.builtin.stat:
+    path: "{{ snipe_install_dir }}"
+  register: snipeit_folder_check
+  become: yes
+
+- name: Create folder if it doesnt exist
+  ansible.builtin.file:
+     path: "{{ snipe_install_dir }}"
+     state: directory
+    mode: '0753'
+  when: not snipeit_folder_check.stat.exists
+  become: yes
+
 - name: Check if .env already exists
   ansible.builtin.stat: 
     path: "{{ snipe_install_dir }}/.env"


### PR DESCRIPTION
Previously, the role would fail if the snipe-it folder didnt exist previously.
This gets now checked and the folder created if it doesnt already exist.