### PR TITLE
 Github Actions tests of playbook

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
 ---
 exclude_paths:
   - tests/
+  - .github/

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -8,4 +8,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run ansible-lint
-        uses: ansible/ansible-lint-action@v6.11
+        uses: ansible/ansible-lint-action@v6.11.0

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -8,4 +8,4 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run ansible-lint
-        uses: ansible/ansible-lint-action@v6.10.2
+        uses: ansible/ansible-lint-action@v6.11

--- a/.github/workflows/ansible-playbook.yml
+++ b/.github/workflows/ansible-playbook.yml
@@ -1,0 +1,35 @@
+name: ansible-role-snipe-it
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test on python ${{ matrix.python_version }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python_version: ['3.9', '3.10', '3.11']
+        os: [ubuntu-22.04, ubuntu-20.04]
+
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version }}
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install ansible
+          printf '[defaults]\nroles_path=../' >ansible.cfg
+      - name: Install ansible-galaxy requirements
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 180
+          max_attempts: 3
+          retry_on: error
+          command: ansible-galaxy install -r tests/requirements.yml
+      - name: Run playbook
+        run: |
+          ansible-playbook tests/test-gha.yml -i tests/inventory

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,7 +7,7 @@
     name: nginx
     state: restarted
 
-- name: Git dubious ownership
+- name: Git dubious ownership # noqa command-instead-of-module
   ansible.builtin.shell: "git config --global --add safe.directory {{ snipe_install_dir }}"
   args:
     executable: /bin/bash

--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -11,7 +11,7 @@
       - git
       - debconf-utils
       - unzip
-      - php-common
+      - "php{{ snipe_php_ver }}-common"
       - php-pear
       - curl
       - gnupg2

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -16,6 +16,8 @@
 
 - name: Delete anonymous user
   community.mysql.mysql_user:
+    login_user: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
+    login_password: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
     name: ""
     host_all: true
     state: absent
@@ -23,6 +25,8 @@
 
 - name: Delete hostname-based root user
   community.mysql.mysql_user:
+    login_user: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
+    login_password: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
     name: root
     host: "{{ ansible_nodename }}"
     state: absent
@@ -30,18 +34,24 @@
 
 - name: Remove test database
   community.mysql.mysql_db:
+    login_user: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
+    login_password: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
     name: test
     state: absent
   become: true
 
 - name: Create snipeit database
   community.mysql.mysql_db:
+    login_user: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
+    login_password: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
     name: "{{ snipe_db_database }}"
     state: present
   become: true
 
 - name: Create snipeit user
   community.mysql.mysql_user:
+    login_user: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
+    login_password: "{{ omit if lookup('ansible.builtin.env', 'GITHUB_ACTIONS') is not defined else 'root' }}"
     name: "{{ snipe_db_username }}"
     password: "{{ snipe_db_password }}"
     priv: "{{ snipe_db_database }}.*:ALL"

--- a/tasks/snipeit.yml
+++ b/tasks/snipeit.yml
@@ -47,7 +47,7 @@
   become: true
 
 - name: Install composer
-  ansible.builtin.shell: set -o pipefail && curl -sS https://getcomposer.org/installer | php
+  ansible.builtin.shell: set -o pipefail && curl -sS https://getcomposer.org/installer | php{{ snipe_php_ver }}
   args:
     chdir: "{{ snipe_install_dir }}"
     executable: /bin/bash
@@ -55,42 +55,42 @@
   become: true
 
 - name: Install snipe dependencies
-  ansible.builtin.shell: "export COMPOSER_ALLOW_SUPERUSER=1; php composer.phar install --no-dev --prefer-source"
+  ansible.builtin.shell: "export COMPOSER_ALLOW_SUPERUSER=1; php{{ snipe_php_ver }} composer.phar install --no-dev --prefer-source"
   args:
     chdir: "{{ snipe_install_dir }}"
     creates: "{{ snipe_install_dir }}/vendor"
   become: true
 
 - name: Dump auto-load
-  ansible.builtin.shell: "export COMPOSER_ALLOW_SUPERUSER=1; php composer.phar dump-autoload"
+  ansible.builtin.shell: "export COMPOSER_ALLOW_SUPERUSER=1; php{{ snipe_php_ver }} composer.phar dump-autoload"
   args:
     chdir: "{{ snipe_install_dir }}"
   changed_when: true
   become: true
 
 - name: Generate app_key
-  ansible.builtin.command: php artisan key:generate --force
+  ansible.builtin.command: php{{ snipe_php_ver }} artisan key:generate --force
   args:
     chdir: "{{ snipe_install_dir }}"
   when: snipe_app_key == 'ChangeMe'
   become: true
 
 - name: Run migrate commands
-  ansible.builtin.command: php artisan migrate --force
+  ansible.builtin.command: php{{ snipe_php_ver }} artisan migrate --force
   args:
     chdir: "{{ snipe_install_dir }}"
   changed_when: true
   become: true
 
 - name: Clear config
-  ansible.builtin.command: php artisan config:clear
+  ansible.builtin.command: php{{ snipe_php_ver }} artisan config:clear
   args:
     chdir: "{{ snipe_install_dir }}"
   changed_when: true
   become: true
 
 - name: Clear cache
-  ansible.builtin.command: php artisan config:cache
+  ansible.builtin.command: php{{ snipe_php_ver }} artisan config:cache
   args:
     chdir: "{{ snipe_install_dir }}"
   changed_when: true

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,2 @@
+collections:
+  - name: nginxinc.nginx_core

--- a/tests/test-gha.yml
+++ b/tests/test-gha.yml
@@ -1,0 +1,25 @@
+---
+- hosts: localhost
+  connection: local
+  remote_user: root
+  roles:
+    - ansible-role-snipe-it
+
+  tasks:
+  - name: Remove default vhost in nginx
+    ansible.builtin.file:
+      path: /etc/nginx/conf.d/default.conf
+      state: absent
+    become: true
+
+  - name: Make sure nginx service is restarted
+    ansible.builtin.systemd:
+      state: restarted
+      name: nginx
+    become: true
+
+  - name: Test reachability of /setup
+    ansible.builtin.uri:
+      url: "http://localhost/setup"
+      method: GET
+    register: _result

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,3 +3,4 @@
   remote_user: root
   roles:
     - snipeit
+    


### PR DESCRIPTION
This introduces a testsuite for the playbook run itself on Ubuntu 22.04 and 20.04 for three python versions.
This includes my changes in the other PR #11 so that should probably be merged first. (or I need to change this, but not today)

Some notes on some of my choices:

re: `.github/workflows/ansible-playbook.yml`
I decided to use `nick-fields/retry@v2` for the ansible-galaxy install because it would randomly fail. This will retry the install thrice before failing for just this specific step.

re: `tasks/mysql.yml`
As the Github Actions Ubuntu images include a mysql server, I had to add the user/password for this as an "omit" parameter to the mysql tasks.

I have tested this separately on another Ubuntu vm, and it works as expected, where the parameter gets omitted if not run inside Github Actions. (as evidenced by the `GITHUB_ACTIONS` environment variable)

re: `tests/test-gha.yml`
Since its a very minimal setup of snipe, the default vhost of the nginx install is kept at localhost, which also means that we need to remove the default.conf that is shipped with nginx to actually be able to reach our snipe-it install via localhost.

I am open to ideas for any better way than to simply test if the /setup uri returns a 200 http response code.
